### PR TITLE
org.filezillaproject.Filezilla -> org.filezilla-project.Filezilla

### DIFF
--- a/org.filezilla-project.Filezilla.json
+++ b/org.filezilla-project.Filezilla.json
@@ -1,5 +1,5 @@
 {
-    "id": "org.filezillaproject.Filezilla",
+    "id": "org.filezilla-project.Filezilla",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.26",
     "sdk": "org.gnome.Sdk",


### PR DESCRIPTION
The domain name is filezilla-project.org (not filezillaproject.org) so let's respect that in the AppStream ID.

I have also submitted an upstream patch to use this ID: https://trac.filezilla-project.org/ticket/11478T