### PR TITLE
remove dconf access

### DIFF
--- a/org.filezillaproject.Filezilla.json
+++ b/org.filezillaproject.Filezilla.json
@@ -16,10 +16,6 @@
             "--talk-name=org.gnome.SessionManager",
             "--filesystem=host",
             "--share=network",
-            "--filesystem=xdg-run/dconf",
-            "--filesystem=~/.config/dconf:ro",
-            "--talk-name=ca.desrt.dconf",
-            "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
             "--require-version=0.10.3",
             "--socket=ssh-auth"
     ],


### PR DESCRIPTION
- remove dconf permission
  - migration not necessary

Cancelled:
```
- convert json to yaml
  - original json does not pass json_verify (due to multiline shell section)
  - yml file verified through yamllinter
```