### PR TITLE
Pass opened URL to application

### DIFF
--- a/desktop-file-mime.patch
+++ b/desktop-file-mime.patch
@@ -1,6 +1,13 @@
---- a/data/filezilla.desktop	2016-01-13 00:54:34.222925070 +0100
-+++ b/data/filezilla.desktop	2016-01-13 12:55:29.670678086 +0100
-@@ -12,3 +12,4 @@
+--- a/data/filezilla.desktop	2024-07-11 22:25:19.068173429 +0100
++++ b/data/filezilla.desktop	2024-07-11 22:27:05.125448402 +0100
+@@ -8,9 +8,10 @@
+ Comment[da]=Download og upload filer via FTP, FTPS og SFTP
+ Comment[de]=Dateien über FTP, FTPS und SFTP übertragen
+ Comment[fr]=Transférer des fichiers via FTP, FTPS et SFTP
+-Exec=filezilla
++Exec=filezilla %u
+ Terminal=false
+ Icon=filezilla
  Type=Application
  Categories=Network;FileTransfer;
  Version=1.0


### PR DESCRIPTION
This patch previously added:

    MimeType=x-scheme-handler/ftp;x-scheme-handler/sftp;x-scheme-handler/ftps;

but did not indicate in the Exec= line where the URL(s) should go.

Per
https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html, %u is a placeholder for a single URL, and will be removed if no URL is being opened.

Fixes https://github.com/flathub/org.filezillaproject.Filezilla/issues/69